### PR TITLE
Whitespace formatting in deps.sh

### DIFF
--- a/RfcxServer/deps.sh
+++ b/RfcxServer/deps.sh
@@ -17,7 +17,6 @@ apt-get install ffmpeg
 apt-get install frei0r-plugins 
 
 # icecast
-
 apt-get install libxslt1-dev
 apt-get install libshout3-dev 
 apt-get install libvorbis-dev


### PR DESCRIPTION
Removed one newline to bring the formatting of the icecast section to be the same as the other sections.